### PR TITLE
Add OCR model test app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv
+ENV/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# OCR-test
+# OCR Model Test App
+
+This repository provides a small application for testing OCR models using [Hugging Face Transformers](https://huggingface.co/docs/transformers/index).
+
+The application loads `reducto/RolmOCR` and lets you upload an image to extract text.
+
+## Requirements
+
+- Python 3.8+
+- [streamlit](https://streamlit.io)
+- [transformers](https://pypi.org/project/transformers/)
+- [torch](https://pytorch.org/) (required by transformers)
+- [Pillow](https://pypi.org/project/Pillow/)
+- [requests](https://pypi.org/project/requests/)
+
+Internet access is required on the first run so that the model can be downloaded from Hugging Face Hub.
+
+Install dependencies with:
+
+```bash
+pip install streamlit transformers torch Pillow requests
+```
+
+## Usage
+
+To launch the app:
+
+```bash
+streamlit run app.py
+```
+
+1. Use the **Import image** widget to upload a picture containing text.
+2. The application will process the image and display the detected text under **OCR result**.
+
+The app also checks whether the model `reducto/RolmOCR` is accessible from Hugging Face. If the model is unavailable or there is a connection issue, an error message will appear.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,44 @@
+import requests
+import streamlit as st
+from PIL import Image
+from transformers import TrOCRProcessor, VisionEncoderDecoderModel
+
+MODEL_ID = "reducto/RolmOCR"
+
+st.title("OCR Model Tester")
+
+@st.cache_resource
+def load_model():
+    """Load the OCR model and processor."""
+    try:
+        model = VisionEncoderDecoderModel.from_pretrained(MODEL_ID)
+        processor = TrOCRProcessor.from_pretrained(MODEL_ID)
+        return model, processor
+    except Exception as e:
+        st.error(f"Failed to load model: {e}")
+        return None, None
+
+@st.cache_data
+def check_model_availability():
+    """Verify that the model is accessible on Hugging Face Hub."""
+    try:
+        resp = requests.get(f"https://huggingface.co/api/models/{MODEL_ID}")
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+if check_model_availability():
+    st.success(f"Model {MODEL_ID} is available.")
+else:
+    st.warning(f"Could not confirm availability of {MODEL_ID}.")
+
+model, processor = load_model()
+
+uploaded_file = st.file_uploader("Import image", type=["png", "jpg", "jpeg"])
+if uploaded_file is not None and model and processor:
+    image = Image.open(uploaded_file).convert("RGB")
+    st.image(image, caption="Uploaded image")
+    inputs = processor(images=image, return_tensors="pt")
+    generated_ids = model.generate(**inputs)
+    result = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+    st.text_area("OCR result", result, height=150)


### PR DESCRIPTION
## Summary
- add Streamlit app to test OCR model `reducto/RolmOCR`
- document requirements and usage in README
- ignore Python virtual environments

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ff84d8ea4832ea690777df8f936bb